### PR TITLE
DI-165 v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This json file provides information about annotations,plugins, required fields a
 
 * Genome build: GRCh37
 * VEP required files:
-  * vep_v105.0.tar.gz
+  * vep_v107.0.tar.gz
   * plugin_config.txt
-  * homo_sapiens_refseq_vep_105_GRCh37.tar.gz
+  * homo_sapiens_refseq_vep_107_GRCh37.tar.gz
   * Homo_sapiens.GRCh37.dna.toplevel.fa.gz
   * Homo_sapiens.GRCh37.dna.toplevel.fa.gz.fai
   * Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi

--- a/cen_vep_config_v1.1.0.json
+++ b/cen_vep_config_v1.1.0.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"CEN",
-        "config_version": "1.0.3"
+        "config_version": "1.1.0"
     },
         "vep_resources":{
         "vep_docker":"file-G8V2Vz0433Gp5bYPF2f6vg9X",

--- a/cen_vep_config_v1.1.0.json
+++ b/cen_vep_config_v1.1.0.json
@@ -88,7 +88,7 @@
     "plugins": [
     {
         "name": "SpliceAI",
-        "pm_file": "file-G8YXQQQ4jKX4bVz53zK7VJX5",
+        "pm_file": "file-GQ7ZJK04vfJVPB7FKybkx0yk",
         "required_fields":"SpliceAI_pred_DS_AG,SpliceAI_pred_DS_AL,SpliceAI_pred_DS_DG,SpliceAI_pred_DS_DL,SpliceAI_pred_DP_AG,SpliceAI_pred_DP_AL,SpliceAI_pred_DP_DG,SpliceAI_pred_DP_DL",
         "resource_files": [
           {
@@ -105,7 +105,7 @@
       },
       {
         "name": "REVEL",
-        "pm_file": "file-G9b5pxQ4jKXGP22y4byPpqq8",
+        "pm_file": "file-GQ7Zf4047GqpFvkbQ5X4p535",
         "required_fields":"REVEL",
         "resource_files": [
           {
@@ -116,7 +116,7 @@
       },
       {
         "name": "CADD",
-        "pm_file": "file-G6BYQGQ433Gg0KfZF5xPfv1X",
+        "pm_file": "file-GQ7ZY6841Jgv0Q5PkBbypJy0",
         "required_fields":"CADD_PHRED",
         "resource_files": [
           {

--- a/cen_vep_config_v1.1.0.json
+++ b/cen_vep_config_v1.1.0.json
@@ -5,9 +5,9 @@
         "config_version": "1.1.0"
     },
         "vep_resources":{
-        "vep_docker":"file-G8V2Vz0433Gp5bYPF2f6vg9X",
-        "plugin_config":"file-G9jZpk8433GvFvX14P775324",
-        "vep_cache":"file-G8V4bGj433Gz96K3Fb1VfbG3",
+        "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
+        "plugin_config":"file-GQ7Yzz04XB7q1vZyY9pQGyjp",
+        "vep_cache":"file-GQ7YF104GV6YQ0B98qyQQP58",
         "reference_fasta":"file-G6BYyyj4YV3pYBkgFVGP2K4P",
         "reference_fai":"file-G6P32kj4YV3y58KyP4k4qG2p",
         "reference_gzi":"file-G6BYz104YV3X5qp463K5b5vp",


### PR DESCRIPTION
Updating VEP CEN config from using VEP version 105 -> 107
- Updated version in filename from cen_vep_config_v1.0.3.json to cen_vep_config_v1.1.0.json
- Updated config version within the file
- Replaced file IDs for vep_docker, plugin_config and vep_cache
- Replaced file IDs for REVEL, CADD and SpliceAI .pm files

Testing doc:
https://cuhbioinformatics.atlassian.net/wiki/spaces/RD/pages/2870935617/DRAFT+-+230314+-+VEP+CEN+Config+file+v1.1.0
Example job:
https://platform.dnanexus.com/projects/GQ7Xk1j4xyx5x12Q5q5pQZpk/monitor/job/GQGFkZQ4xyxJv76Bp9qk31qz

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_CEN_config/6)
<!-- Reviewable:end -->
