### PR TITLE
Updating Clinvar ID and index file to v1.1.3

### DIFF
--- a/cen_vep_config_v1.1.3.json
+++ b/cen_vep_config_v1.1.3.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"CEN",
-        "config_version": "1.1.2"
+        "config_version": "1.1.3"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GQzBBpj4jJkp94yG3yBbJyV6",
-          "index_id":"file-GQzBGF840vgp94yG3yBbJyk7"
+          "file_id":"file-GVfFQVQ4FX0Y9bzPG5YXpqZJ",
+          "index_id":"file-GVfFXP04kKb0vy5y0yb8VypG"
           }
         ]
       },


### PR DESCRIPTION
-  Change filename version from 1.1.2 to 1.1.3
-  In file, change config_version from 1.1.2 to 1.1.3
- Changed file ID and index file for Clinvar b37

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_CEN_config/9)
<!-- Reviewable:end -->
