### PR TITLE
Update Clinvar annotation resource to version 20230819

### DIFF
--- a/cen_vep_config_v1.1.6.json
+++ b/cen_vep_config_v1.1.6.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"CEN",
-        "config_version": "1.1.4"
+        "config_version": "1.1.6"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-GXpQkgQ4Xb45Q36644FY48qk",
-          "index_id":"file-GXpQpY04qqK5pK0z04k6175B"
+          "file_id":"file-GYVX4g04J1YZ1VKg85Yqjvy9",
+          "index_id":"file-GYVX6x84xvQYxf70PGj6PKZZ"
           }
         ]
       },


### PR DESCRIPTION
Updates:

- changed `config_version` from `1.1.4` to `1.1.6`
- changed Clinvar `file_id` and `index_id` to version 20230819

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_CEN_config/14)
<!-- Reviewable:end -->
