### PR TITLE
Update eggd vep config cen v1.1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ This json file provides information about annotations,plugins, required fields a
   * Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi
   * hs37d5.fasta-index.tar.gz
 * Custom Annotation sources:
-  * clinvar_20231217_GRCh37.vcf.gz
+  * clinvar_20240107_GRCh37.vcf.gz
   * gnomad.genomes.r2.1.1.sites.all.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz
   * gnomad.exomes.r2.1.1.sites.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz
   * TWE_POPAF_N500_chr1-22_220413.vcf.gz
-  * HGMD_Pro_2023.3_hg19.vcf.gz
+  * HGMD_Pro_2023.4_hg19.vcf.gz
 * Plugin annotations:
   * REVEL (version May 2022)
     * revel_b37.tsv.gz

--- a/cen_vep_config_v1.1.11.json
+++ b/cen_vep_config_v1.1.11.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh37",
         "assay":"CEN",
-        "config_version": "1.1.10"
+        "config_version": "1.1.11"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-Gf01V2Q44gvxZgVG62zYZkBx",
-          "index_id":"file-Gf02Fb84Qpf95ygBpgVbKP7x"
+          "file_id":"file-GfXVJ8042JQqB9g8KXfzGXBy",
+          "index_id":"file-GfXVKY84fxp06vGxYyKY3BQK"
           }
         ]
       },
@@ -79,8 +79,8 @@
         "required_fields":"HGMD,HGMD_PHEN,HGMD_CLASS,HGMD_RANKSCORE",
         "resource_files": [
           {
-          "file_id": "file-GZfZP7Q4ZZK2JY3PFzy99B2p",
-          "index_id": "file-GZfZPG04ZZK8gBkZPpYKJgYk"
+          "file_id": "file-GfY7K1j4ZZKGygB1BfKVx8fv",
+          "index_id": "file-GfY7K5Q4ZZKJfx60FVFK14kq"
           }
         ]
       }


### PR DESCRIPTION
Updated filename from cen_vep_config_v1.1.10.json to cen_vep_config_v1.1.11.json using `git mv` Inside the config file
- Increase config_version from `1.1.10` to `1.1.11`
- Replaced ClinVar file IDs:
  - file_id: `file-Gf01V2Q44gvxZgVG62zYZkBx` -> `file-GfXVJ8042JQqB9g8KXfzGXBy`
  - index_id: `file-Gf02Fb84Qpf95ygBpgVbKP7x` -> `file-GfXVKY84fxp06vGxYyKY3BQK`
- Replaced HGMD file IDs
  - file_id: `file-GZfZP7Q4ZZK2JY3PFzy99B2p` -> `file-GfY7K1j4ZZKGygB1BfKVx8fv `
  - index_id: `file-GZfZPG04ZZK8gBkZPpYKJgYk` -> `file-GfY7K5Q4ZZKJfx60FVFK14kq`
- Update the Readme file to direct to the latest clinvar file clinvar_20240107_GRCh37.vcf.gz and  HGMF file HGMD_Pro_2023.4_hg19.vcf.gz

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_CEN_config/21)
<!-- Reviewable:end -->
