### PR TITLE
DI-431 Update to add GRCh38 VEP Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,49 @@
 # eggd_vep_CEN_config
-Json configuration file for the implementation of VEP for the CEN assay.
+
+Json configuration files for the implementation of VEP for the CEN assay.
 
 ## What does this config do?
 
 Configuration file required to annotate a vcf using [Variant Effect Predictor](https://github.com/Ensembl/ensembl-vep) implementation [eggd_vep](https://github.com/eastgenomics/eggd_vep).
 
-A variable level of annotation can be achieved by different combinations of custom annotation , vep plugins in addition to the required VEP resources.
+A variable level of annotation can be achieved by different combinations of custom annotation, vep plugins in addition to the required VEP resources.
 
 ## What does this config version contain?
 
-This json file provides information about annotations,plugins, required fields and the genome version.
+This config repo contains two json files for the genome builds GRCh38 and GRCh37.
+These json files provides information about annotations, plugins, required fields and the genome version.
+
+### GRCh38
+
+* Genome build: GRCh38
+* VEP required files:
+  * vep_v107.0.tar.gz
+  * plugin_config.txt
+  * homo_sapiens_refseq_vep_107_GRCh38.tar.gz
+  * Homo_sapiens.GRCh38.dna.toplevel.fa.gz
+  * Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai
+  * Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi
+  * GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18_noChr.fasta-index.tar.gz
+* Custom Annotation sources:
+  * clinvar_20250115_GRCh38.vcf.gz
+  * gnomad.genomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz
+  * gnomad.exomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz
+  * CEN38_POPAF_chr1-22_240503.vcf.gz
+  * TWE38_POPAF_chr1-22_241126.vcf.gz
+  * Medicover38_POPAF_chr1-22_241125.vcf.gz
+  * HGMD_Pro_2024.4_hg38.vcf.gz
+* Plugin annotations:
+  * REVEL (version May 2022)
+    * revel_b38.tsv.gz
+  * CADD (v1.6)
+    * cadd_1.7_b38_whole_genome_SNVs.tsv.gz
+    * cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz
+  * SpliceAI
+    * spliceai_scores.masked.snv.hg38.vcf.gz
+    * spliceai_scores.masked.indel.hg38.vcf.gz
+
+
+### GRCh37
 
 * Genome build: GRCh37
 * VEP required files:
@@ -37,14 +71,12 @@ This json file provides information about annotations,plugins, required fields a
     * spliceai_scores.masked.snv.hg19.vcf.gz
     * spliceai_scores.masked.indel.hg19.vcf.gz
 
-
-
-
 ## Notes
+
   How to check the names of all the files included in the config:
 
 ```bash
-config_file=you_file_name.json
+config_file=<config_filename>.json
 
 # Get the Vep Resources filenames
 for file in  $(jq -r ' .vep_resources | .[]' $config_file);
@@ -62,5 +94,3 @@ do dx describe $file --json | jq -r '.name';
 done
 
 ```
-
-

--- a/README.md
+++ b/README.md
@@ -13,63 +13,25 @@ A variable level of annotation can be achieved by different combinations of cust
 This config repo contains two json files for the genome builds GRCh38 and GRCh37.
 These json files provides information about annotations, plugins, required fields and the genome version.
 
-### GRCh38
-
-* Genome build: GRCh38
-* VEP required files:
-  * vep_v107.0.tar.gz
-  * plugin_config.txt
-  * homo_sapiens_refseq_vep_107_GRCh38.tar.gz
-  * Homo_sapiens.GRCh38.dna.toplevel.fa.gz
-  * Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai
-  * Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi
-  * GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18_noChr.fasta-index.tar.gz
-* Custom Annotation sources:
-  * clinvar_20250115_GRCh38.vcf.gz
-  * gnomad.genomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz
-  * gnomad.exomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz
-  * CEN38_POPAF_chr1-22_240503.vcf.gz
-  * TWE38_POPAF_chr1-22_241126.vcf.gz
-  * Medicover38_POPAF_chr1-22_241125.vcf.gz
-  * HGMD_Pro_2024.4_hg38.vcf.gz
-* Plugin annotations:
-  * REVEL (v1.3, May 2022)
-    * revel_b38.tsv.gz
-  * CADD (v1.7)
-    * cadd_1.7_b38_whole_genome_SNVs.tsv.gz
-    * cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz
-  * SpliceAI
-    * spliceai_scores.masked.snv.hg38.vcf.gz
-    * spliceai_scores.masked.indel.hg38.vcf.gz
-
-
-### GRCh37
-
-* Genome build: GRCh37
-* VEP required files:
-  * vep_v107.0.tar.gz
-  * plugin_config.txt
-  * homo_sapiens_refseq_vep_107_GRCh37.tar.gz
-  * Homo_sapiens.GRCh37.dna.toplevel.fa.gz
-  * Homo_sapiens.GRCh37.dna.toplevel.fa.gz.fai
-  * Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi
-  * hs37d5.fasta-index.tar.gz
-* Custom Annotation sources:
-  * clinvar_20241215_GRCh37.vcf.gz
-  * gnomad.genomes.r2.1.1.sites.all.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz
-  * gnomad.exomes.r2.1.1.sites.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz
-  * TWE_POPAF_N500_chr1-22_220413.vcf.gz
-  * HGMD_Pro_2024.3_hg19.vcf.gz
-* Plugin annotations:
-  * REVEL (v1.3, May 2022)
-    * revel_b37.tsv.gz
-  * CADD (v1.6)
-    * cadd_whole_genome_SNVs_GRCh37.tsv.gz
-    * gnomad.genomes.r2.1.1.indel.tsv.gz
-    * InDels_GRCh37.tsv.gz
-  * SpliceAI
-    * spliceai_scores.masked.snv.hg19.vcf.gz
-    * spliceai_scores.masked.indel.hg19.vcf.gz
+| Key | GRCh37 | GRCh38 |
+|--------------|--------------|--------------|
+| **vep_docker** | vep_v107.0.tar.gz | vep_v107.0.tar.gz |
+| **plugin_config** | plugin_config.txt | plugin_config.txt |
+| **vep_cache** | homo_sapiens_refseq_vep_107_GRCh37.tar.gz | homo_sapiens_refseq_vep_107_GRCh38.tar.gz |
+| **reference_fasta** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz | Homo_sapiens.GRCh38.dna.toplevel.fa.gz |
+| **reference_fai** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.fai | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai |
+| **reference_gzi** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi |
+| **ref_bcftools** | hs37d5.fasta-index.tar.gz | GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18_noChr.fasta-index.tar.gz |
+| **ClinVar** | clinvar_20250115_GRCh37.vcf.gz | clinvar_20250115_GRCh38.vcf.gz | clinvar_20250115_GRCh38.vcf.gz |
+| **gnomAD genomes** | gnomad.genomes.r2.1.1.sites.all.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.genomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
+| **gnomAD exomes** | gnomad.exomes.r2.1.1.sites.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.exomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
+| **CEN** | - | CEN38_POPAF_chr1-22_240503.vcf.gz |
+| **TWE** | TWE_POPAF_N500_chr1-22_220413.vcf.gz | TWE38_POPAF_chr1-22_241126.vcf.gz |
+| **Medicover** | - | Medicover38_POPAF_chr1-22_241125.vcf.gz |
+| **HGMD** | HGMD_Pro_2024.4_hg19.vcf.gz | HGMD_Pro_2024.4_hg38.vcf.gz |
+| **REVEL** | revel_b37.tsv.gz (v1.3, May 2022) | revel_b38.tsv.gz (v1.3 May 2022)
+| **CADD** | cadd_whole_genome_SNVs_GRCh37.tsv.gz, gnomad.genomes.r2.1.1.indel.tsv.gz, InDels_GRCh37.tsv.gz | cadd_1.7_b38_whole_genome_SNVs.tsv.gz,cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz |
+| **SpliceAI** | spliceai_scores.masked.snv.hg19.vcf.gz, spliceai_scores.masked.indel.hg19.vcf.gz | spliceai_scores.masked.snv.hg38.vcf.gz,spliceai_scores.masked.indel.hg38.vcf.gz |
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ These json files provides information about annotations, plugins, required field
 | **reference_fai** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.fai | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai |
 | **reference_gzi** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi |
 | **ref_bcftools** | hs37d5.fasta-index.tar.gz | GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18_noChr.fasta-index.tar.gz |
-| **ClinVar** | clinvar_20250115_GRCh37.vcf.gz | clinvar_20250115_GRCh38.vcf.gz | clinvar_20250115_GRCh38.vcf.gz |
+| **ClinVar** | clinvar_20250115_GRCh37.vcf.gz | clinvar_20250115_GRCh38.vcf.gz |
 | **gnomAD genomes** | gnomad.genomes.r2.1.1.sites.all.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.genomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **gnomAD exomes** | gnomad.exomes.r2.1.1.sites.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.exomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **CEN** | - | CEN38_POPAF_chr1-22_240503.vcf.gz |

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ These json files provides information about annotations, plugins, required field
 | **TWE** | TWE_POPAF_N500_chr1-22_220413.vcf.gz | TWE38_POPAF_chr1-22_241126.vcf.gz |
 | **Medicover** | - | Medicover38_POPAF_chr1-22_241125.vcf.gz |
 | **HGMD** | HGMD_Pro_2024.4_hg19.vcf.gz | HGMD_Pro_2024.4_hg38.vcf.gz |
-| **REVEL** | revel_b37.tsv.gz (v1.3, May 2022) | revel_b38.tsv.gz (v1.3 May 2022)
-| **CADD** | cadd_whole_genome_SNVs_GRCh37.tsv.gz, gnomad.genomes.r2.1.1.indel.tsv.gz, InDels_GRCh37.tsv.gz | cadd_1.7_b38_whole_genome_SNVs.tsv.gz,cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz |
-| **SpliceAI** | spliceai_scores.masked.snv.hg19.vcf.gz, spliceai_scores.masked.indel.hg19.vcf.gz | spliceai_scores.masked.snv.hg38.vcf.gz,spliceai_scores.masked.indel.hg38.vcf.gz |
+| **REVEL** | revel_b37.tsv.gz (v1.3, May 2022) | revel_b38.tsv.gz (v1.3, May 2022) |
+| **CADD** | cadd_whole_genome_SNVs_GRCh37.tsv.gz, gnomad.genomes.r2.1.1.indel.tsv.gz, InDels_GRCh37.tsv.gz | cadd_1.7_b38_whole_genome_SNVs.tsv.gz, cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz |
+| **SpliceAI** | spliceai_scores.masked.snv.hg19.vcf.gz, spliceai_scores.masked.indel.hg19.vcf.gz | spliceai_scores.masked.snv.hg38.vcf.gz, spliceai_scores.masked.indel.hg38.vcf.gz |
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ These json files provides information about annotations, plugins, required field
   * Medicover38_POPAF_chr1-22_241125.vcf.gz
   * HGMD_Pro_2024.4_hg38.vcf.gz
 * Plugin annotations:
-  * REVEL (version May 2022)
+  * REVEL (v1.3, May 2022)
     * revel_b38.tsv.gz
-  * CADD (v1.6)
+  * CADD (v1.7)
     * cadd_1.7_b38_whole_genome_SNVs.tsv.gz
     * cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz
   * SpliceAI
@@ -61,7 +61,7 @@ These json files provides information about annotations, plugins, required field
   * TWE_POPAF_N500_chr1-22_220413.vcf.gz
   * HGMD_Pro_2024.3_hg19.vcf.gz
 * Plugin annotations:
-  * REVEL (version May 2022)
+  * REVEL (v1.3, May 2022)
     * revel_b37.tsv.gz
   * CADD (v1.6)
     * cadd_whole_genome_SNVs_GRCh37.tsv.gz

--- a/cen_vep_config_GRCh38_v1.0.0.json
+++ b/cen_vep_config_GRCh38_v1.0.0.json
@@ -1,0 +1,177 @@
+  {
+    "config_information":{
+        "genome_build": "GRCh38",
+        "assay":"CEN",
+        "config_version": "1.0.0"
+    },
+        "vep_resources":{
+        "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
+        "plugin_config":"file-GQ7Yzz04XB7q1vZyY9pQGyjp",
+        "vep_cache":"file-GQ7Yqpj4qpBvpby694GgX92x",
+        "reference_fasta":"file-G61y95Q433Gk05zyFKF9kFv2",
+        "reference_fai":"file-G61yBV8433GjbVj022PyV3K5",
+        "reference_gzi":"file-G61yBf0433Gp4BBVGj0jxqvP",
+        "ref_bcftools":"file-Gb772VQ4XGyzQ0Zk615XbZ0X"
+    },
+    "custom_annotations": [
+      {
+        "name": "ClinVar",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "CLNSIG,CLNREVSTAT,CLNDN,CLNSIGCONF",
+        "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
+        "resource_files": [
+          {
+          "file_id":"file-Gy72J784jBjZxFxp32GpX6pY",
+          "index_id":"file-Gy72Q2j4XjbkP7FGQGjjjqZb"
+          }
+        ]
+      },
+      {
+        "name": "gnomADg",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "AC,AN,AF,nhomalt",
+        "required_fields":"gnomADg_AC,gnomADg_AN,gnomADg_AF,gnomADg_nhomalt",
+        "resource_files": [
+          {
+          "file_id": "file-Gv81v784JBpxkK585b4FY9b2",
+          "index_id":"file-GvZBvy84JBpYG2yypqQPq3zP"
+          }
+        ]
+      },
+      {
+        "name": "gnomADe",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "AC,AN,AF,nhomalt",
+        "required_fields":"gnomADe_AC,gnomADe_AN,gnomADe_AF,gnomADe_nhomalt",
+        "resource_files": [
+          {
+          "file_id": "file-GvJqP704JBpk2YBB1PzJQkb2",
+          "index_id":"file-GvJqPxQ4JBpz9y18zPg7f5F0"
+          }
+        ]
+      },
+      {
+        "name": "CEN",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "AF,AC_Hom,AC_Het,AN",
+        "required_fields":"CEN_AF,CEN_AC_Hom,CEN_AC_Het,CEN_AN",
+        "resource_files": [
+          {
+          "file_id": "file-GjpKK5Q4bxf3B581FGVZy1f5",
+          "index_id": "file-GjpKKF04bxfJqJqgz543J26g"
+          }
+        ]
+      },
+      {
+        "name": "TWE",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "AF,AC_Hom,AC_Het,AN",
+        "required_fields":"TWE_AF,TWE_AC_Hom,TWE_AC_Het,TWE_AN",
+        "resource_files": [
+          {
+          "file_id": "file-GvzXFkj4JkPFK5VKYkjZKzzY",
+          "index_id": "file-GvzZX904JkP84BQqxvyqG4Pg"
+          }
+        ]
+      },
+      {
+        "name": "Medicover",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "AF,AC_Hom,AC_Het,AN",
+        "required_fields":"Medicover_AF,Medicover_AC_Hom,Medicover_AC_Het,Medicover_AN",
+        "resource_files": [
+          {
+          "file_id": "file-Gx2KV804Pf00Bj3bkXxvf7qk",
+          "index_id": "file-Gx2KVj04Pf09Jq32pbbxyyb3"
+          }
+        ]
+      },
+      {
+        "name": "HGMD",
+        "type": "vcf",
+        "annotation_type": "exact",
+        "force_coordinates": "0",
+        "vcf_fields": "PHEN,RANKSCORE,CLASS",
+        "required_fields":"HGMD,HGMD_PHEN,HGMD_CLASS,HGMD_RANKSCORE",
+        "resource_files": [
+          {
+          "file_id": "file-Gy7pJzj41kgFgbYjBKyPg378",
+          "index_id": "file-Gy7pKY841kgFgbYjBKyPg389"
+          }
+        ]
+      }
+    ],
+    "plugins": [
+    {
+        "name": "SpliceAI",
+        "pm_file": "file-GQ7ZJK04vfJVPB7FKybkx0yk",
+        "required_fields":"SpliceAI_pred_DS_AG,SpliceAI_pred_DS_AL,SpliceAI_pred_DS_DG,SpliceAI_pred_DS_DL,SpliceAI_pred_DP_AG,SpliceAI_pred_DP_AL,SpliceAI_pred_DP_DG,SpliceAI_pred_DP_DL",
+        "resource_files": [
+          {
+            "file_id": "file-G9FFZ18433GpzFVy9XxfyBG4",
+            "index_id": "file-G9FFZb8433GvX5jJ23bQB2z7",
+            "prefix": "snv="
+          },
+          {
+            "file_id": "file-G9FFGbQ433GbXjxQBYy79X75",
+            "index_id": "file-G9FFGX0433GqkpYv23jB853V",
+            "prefix": "indel="
+          }
+        ]
+      },
+      {
+        "name": "REVEL",
+        "pm_file": "file-GQ7Zf4047GqpFvkbQ5X4p535",
+        "required_fields":"REVEL",
+        "resource_files": [
+          {
+            "file_id": "file-G9bzGjQ433GxQQ844VP65q4Z",
+            "index_id": "file-G9bzKz0433Gx66X058gYBYbB"
+          }
+        ]
+      },
+      {
+        "name": "CADD",
+        "pm_file": "file-GQ7ZY6841Jgv0Q5PkBbypJy0",
+        "required_fields":"CADD_PHRED",
+        "resource_files": [
+          {
+            "file_id": "file-GvXK0Zj463q3JyB4k1Z6kFqJ",
+            "index_id": "file-GvXJ4304ZJz333bkQX06vKZx"
+          },
+          {
+            "file_id": "file-GvXJ5J041Jq97byQfyb9JF3z",
+            "index_id": "file-GvXJ5Vj4k5331YfvbVz98J22"
+          }
+        ]
+      }
+    ],
+    "additional_fields":[
+        "Allele",
+        "SYMBOL",
+        "HGNC_ID",
+        "VARIANT_CLASS",
+        "Consequence",
+        "IMPACT",
+        "EXON",
+        "INTRON",
+        "Feature",
+        "HGVSc",
+        "HGVSp",
+        "HGVS_OFFSET",
+        "Existing_variation",
+        "STRAND"
+    ]
+  }

--- a/cen_vep_config_GRCh38_v1.0.0.json
+++ b/cen_vep_config_GRCh38_v1.0.0.json
@@ -33,8 +33,8 @@
         "type": "vcf",
         "annotation_type": "exact",
         "force_coordinates": "0",
-        "vcf_fields": "AC,AN,AF,nhomalt",
-        "required_fields":"gnomADg_AC,gnomADg_AN,gnomADg_AF,gnomADg_nhomalt",
+        "vcf_fields": "AC,AN,AF,nhomalt,grpmax,AC_grpmax,AN_grpmax,AF_grpmax,nhomalt_grpmax",
+        "required_fields":"gnomADg_AC,gnomADg_AN,gnomADg_AF,gnomADg_nhomalt,gnomADg_grpmax,gnomADg_AC_grpmax,gnomADg_AN_grpmax,gnomADg_AF_grpmax,gnomADg_nhomalt_grpmax",
         "resource_files": [
           {
           "file_id": "file-Gv81v784JBpxkK585b4FY9b2",
@@ -47,8 +47,8 @@
         "type": "vcf",
         "annotation_type": "exact",
         "force_coordinates": "0",
-        "vcf_fields": "AC,AN,AF,nhomalt",
-        "required_fields":"gnomADe_AC,gnomADe_AN,gnomADe_AF,gnomADe_nhomalt",
+        "vcf_fields": "AC,AN,AF,nhomalt,grpmax,AC_grpmax,AN_grpmax,AF_grpmax,nhomalt_grpmax",
+        "required_fields":"gnomADe_AC,gnomADe_AN,gnomADe_AF,gnomADe_nhomalt,gnomADe_grpmax,gnomADe_AC_grpmax,gnomADe_AN_grpmax,gnomADe_AF_grpmax,gnomADe_nhomalt_grpmax",
         "resource_files": [
           {
           "file_id": "file-GvJqP704JBpk2YBB1PzJQkb2",


### PR DESCRIPTION
Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12-R46): Expanded to include detailed information about the genome builds GRCh38 and GRCh37, including required files, custom annotation sources, and plugin annotations.

New configuration file:
* [`cen_vep_config_GRCh38_v1.0.0.json`](diffhunk://#diff-81f418f93612ed4b921501be4bad257018d4d0cc2231ccc00f0d356d4bf1b6a6R1-R177): Added a new JSON configuration file for the GRCh38 genome build, detailing the VEP resources, custom annotations, plugins, and additional fields required for the CEN assay.
   * b38 VEP 107 cache
   * b38 ref FASTA (+fai+gzi), bcftools index
   * ClinVar b38
   * gnomADe and gnomADg to v4.1
   * Added CEN internal AFs b38
   * Added Medicover internal AFs b38
   * TWE internal AFs b38
   * HGMD b38
   * REVEL b38
   * CADD (v1.7) b38
   * SpliceAI b38

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_CEN_config/34)
<!-- Reviewable:end -->
