### PR TITLE
Update the README file to include the new Exclusion/inclusion annotation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ These json files provides information about annotations, plugins, required field
 | **REVEL** | revel_b37.tsv.gz (v1.3, May 2022) | revel_b38.tsv.gz (v1.3, May 2022) |
 | **CADD** | cadd_whole_genome_SNVs_GRCh37.tsv.gz, gnomad.genomes.r2.1.1.indel.tsv.gz, InDels_GRCh37.tsv.gz | cadd_1.7_b38_whole_genome_SNVs.tsv.gz, cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz |
 | **SpliceAI** | spliceai_scores.masked.snv.hg19.vcf.gz, spliceai_scores.masked.indel.hg19.vcf.gz | spliceai_scores.masked.snv.hg38.vcf.gz, spliceai_scores.masked.indel.hg38.vcf.gz |
+| **IncludeVariant** | GRCh37_inclusion_list_v1.0.1.vcf.gz | - |
+| **ExcludeVariant** | GRCh37_optimised_filtering_excluded_variants_v1.0.1.vcf.gz | - |
 
 
 ## Notes


### PR DESCRIPTION
The GRCh37_inclusion_list_v1.0.1.vcf.gz  and GRCh37_optimised_filtering_excluded_variants_v1.0.1.vcf.gz have been included in the README.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_CEN_config/39)
<!-- Reviewable:end -->
