### PR TITLE
NG-555_cen_vep_config_GRCh38_v1.1.1.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ These json files provides information about annotations, plugins, required field
 | **reference_fai** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.fai | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai |
 | **reference_gzi** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi |
 | **ref_bcftools** | hs37d5.fasta-index.tar.gz | GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18_noChr.fasta-index.tar.gz |
-| **ClinVar** | clinvar_20250415_GRCh37.vcf.gz | clinvar_20250415_GRCh38.vcf.gz |
+| **ClinVar** | clinvar_20250415_GRCh37.vcf.gz | clinvar_20250504_GRCh38.vcf.gz |
 | **gnomAD genomes** | gnomad.genomes.r2.1.1.sites.all.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.genomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **gnomAD exomes** | gnomad.exomes.r2.1.1.sites.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.exomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **CEN** | - | CEN38_POPAF_chr1-22_240503.vcf.gz |

--- a/cen_vep_config_GRCh38_v1.1.1.json
+++ b/cen_vep_config_GRCh38_v1.1.1.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh38",
         "assay":"CEN",
-        "config_version": "1.1.0"
+        "config_version": "1.1.1"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-J03jqf04XYKGP6b0q38724k2",
-          "index_id":"file-J03jqq841VyX8F50kjq0p858"
+          "file_id":"file-J0bXbf04689YBQ5vby0QZk58",
+          "index_id":"file-J0bXg2Q4xqy82gKpy5bVv100"
           }
         ]
       },


### PR DESCRIPTION
Existing cen_vep_config file was renamed by using git mv to increase version in the filename (i.e. from v1.1.0 to v1.1.1). Within the file:
- Update config version from "config_version": "1.1.0" to "config_version": "1.1.1"
- Update the ClinVar annotation reference file sources:
  - “file_id”:  file-J0bXbf04689YBQ5vby0QZk58
  - “index_id”: file-J0bXg2Q4xqy82gKpy5bVv100

README was updated to reference the correct file versions for the updated ClinVar file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_CEN_config/43)
<!-- Reviewable:end -->
