### PR TITLE
update b38 config to use the latest clinvar and exclusion list versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ These json files provides information about annotations, plugins, required field
 | **reference_fai** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.fai | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai |
 | **reference_gzi** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi |
 | **ref_bcftools** | hs37d5.fasta-index.tar.gz | GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18_noChr.fasta-index.tar.gz |
-| **ClinVar** | clinvar_20250415_GRCh37.vcf.gz | clinvar_20250504_GRCh38.vcf.gz |
+| **ClinVar** | clinvar_20250415_GRCh37.vcf.gz | clinvar_20250615_GRCh38.vcf.gz |
 | **gnomAD genomes** | gnomad.genomes.r2.1.1.sites.all.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.genomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **gnomAD exomes** | gnomad.exomes.r2.1.1.sites.noVEP_normalised_decomposed_PASS.dias_trimmed_v1.0.0.vcf.bgz | gnomad.exomes.v4.1.sites.all.trimmed_normalised_decomposed_PASS.no_chr.vcf.bgz |
 | **CEN** | - | CEN38_POPAF_chr1-22_240503.vcf.gz |
@@ -33,7 +33,7 @@ These json files provides information about annotations, plugins, required field
 | **CADD** | cadd_whole_genome_SNVs_GRCh37.tsv.gz, gnomad.genomes.r2.1.1.indel.tsv.gz, InDels_GRCh37.tsv.gz | cadd_1.7_b38_whole_genome_SNVs.tsv.gz, cadd.1.7.b38.gnomad.genomes.r4.0.indel.tsv.gz |
 | **SpliceAI** | spliceai_scores.masked.snv.hg19.vcf.gz, spliceai_scores.masked.indel.hg19.vcf.gz | spliceai_scores.masked.snv.hg38.vcf.gz, spliceai_scores.masked.indel.hg38.vcf.gz |
 | **IncludeVariant** | GRCh37_inclusion_list_v1.0.1.vcf.gz | GRCh38_inclusion_list_v1.0.0.vcf.gz |
-| **ExcludeVariant** | GRCh37_optimised_filtering_excluded_variants_v1.0.1.vcf.gz | GRCh38_exclusion_list_v1.0.1.vcf.gz |
+| **ExcludeVariant** | GRCh37_optimised_filtering_excluded_variants_v1.0.1.vcf.gz | GRCh38_exclusion_list_v1.1.0.vcf.gz |
 
 
 ## Notes

--- a/cen_vep_config_GRCh38_v1.1.2.json
+++ b/cen_vep_config_GRCh38_v1.1.2.json
@@ -2,7 +2,7 @@
     "config_information":{
         "genome_build": "GRCh38",
         "assay":"CEN",
-        "config_version": "1.1.1"
+        "config_version": "1.1.2"
     },
         "vep_resources":{
         "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
@@ -23,8 +23,8 @@
         "required_fields":"ClinVar,ClinVar_CLNSIG,ClinVar_CLNSIGCONF,ClinVar_CLNDN",
         "resource_files": [
           {
-          "file_id":"file-J0bXbf04689YBQ5vby0QZk58",
-          "index_id":"file-J0bXg2Q4xqy82gKpy5bVv100"
+          "file_id":"file-J17yQJQ4B56XX9bX6pY8VpKf",
+          "index_id":"file-J17yVFQ44B02y5kJqykBf75V"
           }
         ]
       },
@@ -121,8 +121,8 @@
         "required_fields":"ExcludeVariant_ExcludeList",
         "resource_files": [
           {
-          "file_id":"file-J08F84j4z6jBfYgX5VJYYP5q",
-          "index_id":"file-J08F86Q4z6j6bP1pBFBJxJ7q"
+          "file_id":"file-J1602g84zV9kbzK3FPz9PZx3",
+          "index_id":"file-J1608Q04zV9qjKk30qX3Y176"
           }
         ]
       },


### PR DESCRIPTION
- Increment config to version v1.1.2
- Update config and readme to use clinvar version 20250615 for b38 and exclusion list version v1.1.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_CEN_config/44)
<!-- Reviewable:end -->
